### PR TITLE
replace /home/masa with ${HOME}

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -37,4 +37,4 @@ if [ -d "${RBENV_ROOT}" ]; then
   eval "$(rbenv init -)"
 fi
 # The next line updates PATH for the Google Cloud SDK.
-if [ -f '/home/masa/google-cloud-sdk/path.bash.inc' ]; then . '/home/masa/google-cloud-sdk/path.bash.inc'; fi
+if [ -f '${HOME}/google-cloud-sdk/path.bash.inc' ]; then . '${HOME}/google-cloud-sdk/path.bash.inc'; fi

--- a/.config/Zeal/Zeal.conf
+++ b/.config/Zeal/Zeal.conf
@@ -21,7 +21,7 @@ serif_font_family=Cica
 smooth_scrolling=false
 
 [docsets]
-path=/home/masa/doc
+path=${HOME}/doc
 
 [global_shortcuts]
 show=

--- a/.config/autostart/autostart.desktop
+++ b/.config/autostart/autostart.desktop
@@ -2,7 +2,7 @@
 Name=AutoStart
 GenericName=Auto Start Script
 Comment=no comment
-Exec=/home/masa/.auto_start.sh
+Exec=${HOME}/.auto_start.sh
 Icon=utilities-terminal
 Terminal=true
 Type=Application

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-prefix=/home/masa/.node_modules
+prefix=${HOME}/.node_modules

--- a/.screenrc
+++ b/.screenrc
@@ -26,7 +26,7 @@ bind U eval "encoding utf-8" "!!!echo 'export LANG=ja_JP.UTF-8'"
 bind E eval "encoding euc" "!!!echo 'export LANG=ja_JP.EUC-JP'"
 
 # Log setting
-hardcopydir /home/masa/screen
+hardcopydir ${HOME}/screen
 
 # Screen 256 colors
 term screen-256color

--- a/.zshrc
+++ b/.zshrc
@@ -792,7 +792,7 @@ source ~/backup/zsh/env.sh
 source /usr/share/nvm/init-nvm.sh
 
 # The next line updates PATH for the Google Cloud SDK.
-if [ -f '/home/masa/google-cloud-sdk/path.zsh.inc' ]; then . '/home/masa/google-cloud-sdk/path.zsh.inc'; fi
+if [ -f '${HOME}/google-cloud-sdk/path.zsh.inc' ]; then . '${HOME}/google-cloud-sdk/path.zsh.inc'; fi
 
 # The next line enables shell command completion for gcloud.
-if [ -f '/home/masa/google-cloud-sdk/completion.zsh.inc' ]; then . '/home/masa/google-cloud-sdk/completion.zsh.inc'; fi
+if [ -f '${HOME}/google-cloud-sdk/completion.zsh.inc' ]; then . '${HOME}/google-cloud-sdk/completion.zsh.inc'; fi

--- a/backup_sample/bash/.bash_history
+++ b/backup_sample/bash/.bash_history
@@ -4,7 +4,7 @@ sudo pacman -S zsh git
 sudo pacman -S noto-fonts
 sudo pacman -S noto-fonts-cjk
 sudo pacman -S chromium
-mkdir -p /home/masa/src/github.com/aur
+mkdir -p ~/src/github.com/aur
 cd src/github.com/aur/
 git clone https://aur.archlinux.org/yay.git
 cd yay/

--- a/usr/share/applications/toggle.desktop
+++ b/usr/share/applications/toggle.desktop
@@ -2,7 +2,7 @@
 Name=Toggle
 GenericName=Toggle Script
 Comment=no comment
-Exec=/home/masa/src/github.com/masasam/dotfiles/.toggle.sh
+Exec=${HOME}/src/github.com/masasam/dotfiles/.toggle.sh
 Icon=utilities-terminal
 Terminal=true
 Type=Application


### PR DESCRIPTION
Thanks for sharing the great dotfiles.

Some scripts/programs fail if "/home/masa" does not exist.
"/home/masa" in sample configurations are harmless, but they need to be customized.
So, I picked up the string and replaced them with ${HOME} and ~/.

"src/github.com/masasam/dotfiles" must be there, so not changed.